### PR TITLE
Fix #17. Handle undefined user on first redirect attempt

### DIFF
--- a/src/authentication-service.js
+++ b/src/authentication-service.js
@@ -263,7 +263,7 @@ function authenticationFactory($q, $localStorage, $cookies, environmentsService,
    * @returns {boolean}
    */
   function isAuthenticated() {
-    return service.getUser() !== null;
+    return !!service.getUser();
   }
 
   /**

--- a/test/authentication-service.spec.js
+++ b/test/authentication-service.spec.js
@@ -404,9 +404,13 @@ describe('authenticationService', function () {
         expect(authenticationService.isAuthenticated()).toBeTruthy();
       });
 
-      it('returns true if there is no authenticated user', function () {
+      it('returns false if there is no authenticated user', function () {
         $localStorage.user = null;
 
+        expect(authenticationService.isAuthenticated()).toBeFalsy();
+      });
+      it('returns false if the user is undefined', function () {
+        $localStorage.user = undefined;
         expect(authenticationService.isAuthenticated()).toBeFalsy();
       });
     });


### PR DESCRIPTION
We weren't handling the case where the user is undefined.